### PR TITLE
Resizable tracks

### DIFF
--- a/include/Editor.h
+++ b/include/Editor.h
@@ -43,8 +43,8 @@ class DropToolBar;
 
 /// \brief Superclass for editors with a toolbar.
 ///
-/// Those editors include the Song Editor, the Automation Editor, B&B Editor,
-/// and the Piano Roll.
+/// Those editors include SongEditorWindow, AutomationEditorWindow, PatternEditorWindow,
+/// and PianoRollWindow.
 class Editor : public QMainWindow
 {
 	Q_OBJECT

--- a/include/PatternEditor.h
+++ b/include/PatternEditor.h
@@ -44,6 +44,8 @@ class PatternEditor : public TrackContainerView
 {
 	Q_OBJECT
 public:
+	static constexpr int MIN_PATTERN_WIDTH = 200;
+
 	PatternEditor(PatternStore* ps);
 
 	bool fixedClips() const override
@@ -52,8 +54,7 @@ public:
 	}
 
 	void removeViewsForPattern(int pattern);
-
-	static constexpr const int MinPatternWidthPixels = 384;
+	void setTrackHeadWidth(int width) override;
 
 public slots:
 	void addSteps();
@@ -71,10 +72,17 @@ protected slots:
 	void updatePixelsPerBar();
 
 private:
+	//! This function only exists because the pattern editor cannot yet handle scrolling, so the track head cannot
+	//! extend too far or it will cause the clips to have 0 width.
+	//! Once proper scrolling and zooming is implemented, this can be removed.
+	int maxTrackHeadWidth() const;
+
 	PatternStore* m_ps;
 	TimeLineWidget* m_timeLine;
 	tick_t m_maxClipLength;
 	void makeSteps( bool clone );
+
+	int m_userTrackHeadWidth;
 };
 
 

--- a/include/PatternEditor.h
+++ b/include/PatternEditor.h
@@ -53,9 +53,6 @@ public:
 
 	void removeViewsForPattern(int pattern);
 
-	void saveSettings(QDomDocument& doc, QDomElement& element) override;
-	void loadSettings(const QDomElement& element) override;
-
 	static constexpr const int MinPatternWidthPixels = 384;
 
 public slots:

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -67,9 +67,6 @@ public:
 	SongEditor( Song * song );
 	~SongEditor() override = default;
 
-	void saveSettings( QDomDocument& doc, QDomElement& element ) override;
-	void loadSettings( const QDomElement& element ) override;
-
 	ComboBoxModel *snappingModel() const;
 	float getSnapSize() const;
 	QString getSnapSizeString() const;

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -71,6 +71,11 @@ class TrackContainerView : public QWidget, public ModelView,
 {
 	Q_OBJECT
 public:
+	// Track head (everything left of the timeline) width in pixels
+	static constexpr int DEFAULT_TRACK_HEAD_WIDTH = 338;
+	static constexpr int COMPACT_TRACK_HEAD_WIDTH = 214;
+	static constexpr int MIN_TRACK_HEAD_WIDTH = 168;
+
 	TrackContainerView( TrackContainer* tc );
 	~TrackContainerView() override;
 
@@ -141,12 +146,10 @@ public:
 	// -------------------------------------------------------
 
 	int getTrackHeadWidth() const { return m_trackHeadWidth; }
-	void setTrackHeadWidth(int width);
+	virtual void setTrackHeadWidth(int width);
 
-	//! This function only exists because the pattern editor cannot yet handle scrolling, so the track head cannot
-	//! extend too far or it will cause the clips to have 0 width.
-	//! Once proper scrolling and zooming is implemented, this can be removed.
-	void setMaxTrackHeadWidth(int maxWidth);
+	//! Default track head width, depending on user setting
+	static int userDefaultTrackHeadWidth();
 
 	void clearAllTracks();
 
@@ -205,9 +208,6 @@ private:
 	float m_ppb;
 
 	int m_trackHeadWidth;
-
-	//! This variable can be removed once the Pattern Editor supports scrolling.
-	int m_maxTrackHeadWidth = -1;
 
 	RubberBand * m_rubberBand;
 

--- a/include/TrackView.h
+++ b/include/TrackView.h
@@ -50,15 +50,14 @@ class TrackContainerView;
 
 const int TRACK_OP_WIDTH = 78;
 
-const int DEFAULT_TRACK_WIDTH = 338;
-const int COMPACT_TRACK_WIDTH = 214;
-const int MINIMUM_TRACK_WIDTH = 168;
-
 
 class TrackView : public QWidget, public ModelView, public JournallingObject
 {
 	Q_OBJECT
 public:
+	/*! The width of the resize grip in pixels */
+	static constexpr int RESIZE_GRIP_WIDTH = 6;
+
 	TrackView( Track * _track, TrackContainerView* tcv );
 	~TrackView() override = default;
 
@@ -102,9 +101,6 @@ public:
 	// Create a menu for assigning/creating channels for this track
 	// Currently instrument track and sample track supports it
 	virtual QMenu * createMixerMenu(QString title, QString newMixerLabel);
-
-	/*! The width of the resize grip in pixels */
-	static constexpr int ResizeGripWidth = 6;
 
 
 public slots:

--- a/include/TrackView.h
+++ b/include/TrackView.h
@@ -46,6 +46,7 @@ namespace gui
 
 class FadeButton;
 class TrackContainerView;
+class TrackResizeLine;
 
 
 const int TRACK_OP_WIDTH = 78;
@@ -56,7 +57,7 @@ class TrackView : public QWidget, public ModelView, public JournallingObject
 	Q_OBJECT
 public:
 	/*! The width of the resize grip in pixels */
-	static constexpr int RESIZE_GRIP_WIDTH = 6;
+	static constexpr int RESIZE_GRIP_WIDTH = 4;
 
 	TrackView( Track * _track, TrackContainerView* tcv );
 	~TrackView() override = default;
@@ -129,9 +130,7 @@ protected:
 
 	void dragEnterEvent( QDragEnterEvent * dee ) override;
 	void dropEvent( QDropEvent * de ) override;
-	void mousePressEvent( QMouseEvent * me ) override;
 	void mouseMoveEvent( QMouseEvent * me ) override;
-	void mouseReleaseEvent( QMouseEvent * me ) override;
 	void wheelEvent(QWheelEvent* we) override;
 	void paintEvent( QPaintEvent * pe ) override;
 	void resizeEvent( QResizeEvent * re ) override;
@@ -157,6 +156,10 @@ private:
 	QWidget m_trackSettingsWidget;
 	// Widget that is the timeline where ClipViews are placed
 	TrackContentWidget m_trackContentWidget;
+	// Resize handle at the bottom of each track
+	TrackResizeLine* m_heightResizeLine;
+	// Resize handle to the right of track label and controls
+	TrackResizeLine* m_widthResizeLine;
 
 	Action m_action;
 
@@ -168,6 +171,7 @@ private:
 	void setIndicatorMute(FadeButton* indicator, bool muted);
 
 	friend class TrackLabelButton;
+	friend class TrackResizeLine;
 
 
 private slots:
@@ -175,8 +179,22 @@ private slots:
 	void muteChanged();
 	void onTrackGripGrabbed();
 	void onTrackGripReleased();
-	void updateWidth(int width);
+	void updateTrackHeadWidth(int width);
 } ;
+
+
+class TrackResizeLine : public QWidget
+{
+	Q_OBJECT
+public:
+	TrackResizeLine(TrackView* tv, TrackView::Action action, Qt::CursorShape cursor);
+protected:
+	void mousePressEvent(QMouseEvent* me) override;
+	void mouseReleaseEvent(QMouseEvent* me) override;
+private:
+	TrackView* m_trackView;
+	TrackView::Action m_action;
+};
 
 
 } // namespace gui

--- a/include/TrackView.h
+++ b/include/TrackView.h
@@ -155,8 +155,11 @@ private:
 	Track * m_track;
 	TrackContainerView * m_trackContainerView;
 
+	// Widget that contains the menu, mute and solo buttons
 	TrackOperationsWidget m_trackOperationsWidget;
+	// Empty widget where each track class may add a label, FX channel, volume knobs, etc
 	QWidget m_trackSettingsWidget;
+	// Widget that is the timeline where ClipViews are placed
 	TrackContentWidget m_trackContentWidget;
 
 	Action m_action;

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -130,21 +130,6 @@ void PatternEditor::removeViewsForPattern(int pattern)
 
 
 
-void PatternEditor::saveSettings(QDomDocument& doc, QDomElement& element)
-{
-	MainWindow::saveWidgetState( parentWidget(), element );
-	element.setAttribute("trackheadwidth", getTrackHeadWidth());
-}
-
-void PatternEditor::loadSettings(const QDomElement& element)
-{
-	MainWindow::restoreWidgetState(parentWidget(), element);
-	setTrackHeadWidth(element.attribute("trackheadwidth", QString::number(getTrackHeadWidth())).toInt());
-	updateMaxSteps();
-}
-
-
-
 
 void PatternEditor::dropEvent(QDropEvent* de)
 {

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -50,7 +50,8 @@ namespace lmms::gui
 PatternEditor::PatternEditor(PatternStore* ps) :
 	TrackContainerView(ps),
 	m_ps(ps),
-	m_maxClipLength(TimePos::ticksPerBar())
+	m_maxClipLength(TimePos::ticksPerBar()),
+	m_userTrackHeadWidth(userDefaultTrackHeadWidth())
 {
 	setModel(ps);
 
@@ -175,7 +176,24 @@ void PatternEditor::dropEvent(QDropEvent* de)
 void PatternEditor::resizeEvent(QResizeEvent* re)
 {
 	updatePixelsPerBar();
-	setMaxTrackHeadWidth(width() - MinPatternWidthPixels - 2 * ClipView::BORDER_WIDTH);
+
+	// Decrease size of track head if it's too big to fit the pattern.
+	// Call TrackContainerView so m_userTrackHeadWidth doesn't change.
+	TrackContainerView::setTrackHeadWidth(std::min(m_userTrackHeadWidth, maxTrackHeadWidth()));
+}
+
+
+int PatternEditor::maxTrackHeadWidth() const
+{
+	return width() - MIN_PATTERN_WIDTH - 2 * ClipView::BORDER_WIDTH;
+}
+
+
+void PatternEditor::setTrackHeadWidth(int width)
+{
+	// Track head has been manually resized, save the value
+	m_userTrackHeadWidth = width;
+	TrackContainerView::setTrackHeadWidth(std::min(m_userTrackHeadWidth, maxTrackHeadWidth()));
 }
 
 
@@ -274,7 +292,7 @@ PatternEditorWindow::PatternEditorWindow(PatternStore* ps) :
 	connect(m_toolBar, SIGNAL(dragEntered(QDragEnterEvent*)), m_editor, SLOT(dragEnterEvent(QDragEnterEvent*)));
 	connect(m_toolBar, SIGNAL(dropped(QDropEvent*)), m_editor, SLOT(dropEvent(QDropEvent*)));
 
-	setMinimumWidth(MINIMUM_TRACK_WIDTH + 2 * ClipView::BORDER_WIDTH + PatternEditor::MinPatternWidthPixels);
+	setMinimumWidth(TrackContainerView::MIN_TRACK_HEAD_WIDTH + 2 * ClipView::BORDER_WIDTH + PatternEditor::MIN_PATTERN_WIDTH);
 
 	m_playAction->setToolTip(tr("Play/pause current pattern (Space)"));
 	m_stopAction->setToolTip(tr("Stop playback of current pattern (Space)"));
@@ -334,7 +352,7 @@ PatternEditorWindow::PatternEditorWindow(PatternStore* ps) :
 
 QSize PatternEditorWindow::sizeHint() const
 {
-	return {m_editor->getTrackHeadWidth() + 2 * ClipView::BORDER_WIDTH + PatternEditor::MinPatternWidthPixels, 300};
+	return {m_editor->getTrackHeadWidth() + 2 * ClipView::BORDER_WIDTH + PatternEditor::MIN_PATTERN_WIDTH, 300};
 }
 
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -274,20 +274,6 @@ SongEditor::SongEditor( Song * song ) :
 
 
 
-void SongEditor::saveSettings( QDomDocument& doc, QDomElement& element )
-{
-	MainWindow::saveWidgetState( parentWidget(), element );
-	element.setAttribute("trackheadwidth", getTrackHeadWidth());
-}
-
-void SongEditor::loadSettings( const QDomElement& element )
-{
-	MainWindow::restoreWidgetState(parentWidget(), element);
-	setTrackHeadWidth(element.attribute("trackheadwidth", QString::number(getTrackHeadWidth())).toInt());
-}
-
-
-
 
 /*! \brief Return grid size as number of bars */
 float SongEditor::getSnapSize() const

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -139,7 +139,9 @@ TrackContainerView::~TrackContainerView()
 void TrackContainerView::saveSettings( QDomDocument & _doc,
 							QDomElement & _this )
 {
-	MainWindow::saveWidgetState( this, _this );
+	// Save window position of our parent widget, e.g. SongEditorWindow/PatternEditorWindow
+	if (parentWidget()) { MainWindow::saveWidgetState(parentWidget(), _this); }
+	_this.setAttribute("trackheadwidth", getTrackHeadWidth());
 }
 
 
@@ -147,9 +149,10 @@ void TrackContainerView::saveSettings( QDomDocument & _doc,
 
 void TrackContainerView::loadSettings( const QDomElement & _this )
 {
-	MainWindow::restoreWidgetState( this, _this );
+	// Restore window position of our parent widget, e.g. SongEditorWindow/PatternEditorWindow
+	if (parentWidget()) { MainWindow::restoreWidgetState(parentWidget(), _this); }
+	setTrackHeadWidth(_this.attribute("trackheadwidth", QString::number(getTrackHeadWidth())).toInt());
 }
-
 
 
 

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -84,7 +84,7 @@ TrackContainerView::TrackContainerView( TrackContainer * _tc ) :
 	m_trackViews(),
 	m_scrollArea( new scrollArea( this ) ),
 	m_ppb( DEFAULT_PIXELS_PER_BAR ),
-	m_trackHeadWidth(ConfigManager::inst()->value("ui", "compacttrackbuttons").toInt() ? COMPACT_TRACK_WIDTH : DEFAULT_TRACK_WIDTH),
+	m_trackHeadWidth(userDefaultTrackHeadWidth()),
 	m_rubberBand( new RubberBand( m_scrollArea ) )
 {
 	m_tc->setHook( this );
@@ -151,7 +151,7 @@ void TrackContainerView::loadSettings( const QDomElement & _this )
 {
 	// Restore window position of our parent widget, e.g. SongEditorWindow/PatternEditorWindow
 	if (parentWidget()) { MainWindow::restoreWidgetState(parentWidget(), _this); }
-	setTrackHeadWidth(_this.attribute("trackheadwidth", QString::number(getTrackHeadWidth())).toInt());
+	setTrackHeadWidth(_this.attribute("trackheadwidth", QString::number(userDefaultTrackHeadWidth())).toInt());
 }
 
 
@@ -358,17 +358,13 @@ void TrackContainerView::setPixelsPerBar( int ppb )
 
 void TrackContainerView::setTrackHeadWidth(int width)
 {
-	m_trackHeadWidth = m_maxTrackHeadWidth > 0
-		? std::clamp(width, MINIMUM_TRACK_WIDTH, m_maxTrackHeadWidth)
-		: std::max(width, MINIMUM_TRACK_WIDTH);
+	m_trackHeadWidth = std::max(width, MIN_TRACK_HEAD_WIDTH);
 	emit trackHeadWidthChanged(m_trackHeadWidth);
 }
 
-void TrackContainerView::setMaxTrackHeadWidth(int maxWidth)
+int TrackContainerView::userDefaultTrackHeadWidth()
 {
-	m_maxTrackHeadWidth = maxWidth;
-	// Update width
-	setTrackHeadWidth(m_trackHeadWidth);
+	return ConfigManager::inst()->value("ui", "compacttrackbuttons").toInt() ? COMPACT_TRACK_HEAD_WIDTH : DEFAULT_TRACK_HEAD_WIDTH;
 }
 
 

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -77,12 +77,14 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 			this, SLOT(handleConfigChange(QString,QString,QString)));
 
 	m_mixerChannelNumber = new MixerChannelLcdSpinBox(2, getTrackSettingsWidget(), tr("Mixer channel"), this);
-	m_mixerChannelNumber->show();
 
-	connect(trackContainerView(), &TrackContainerView::trackHeadWidthChanged, this, [this](int width){
-		if (width < COMPACT_TRACK_WIDTH) { m_mixerChannelNumber->hide(); }
-		else { m_mixerChannelNumber->show(); }
-	});
+	auto updateChannelNumberVisibility = [this]()
+	{
+		m_mixerChannelNumber->setVisible((getTrackOperationsWidget()->width() + getTrackSettingsWidget()->width()) >= COMPACT_TRACK_WIDTH);
+	};
+
+	connect(tcv, &TrackContainerView::trackHeadWidthChanged, this, updateChannelNumberVisibility);
+	updateChannelNumberVisibility();
 
 	m_volumeKnob = new Knob(KnobType::Small17, tr("VOL"), getTrackSettingsWidget(), Knob::LabelRendering::LegacyFixedFontSize, tr("VOL"));
 	m_volumeKnob->setVolumeKnob( true );

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -80,7 +80,7 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 
 	auto updateChannelNumberVisibility = [this]()
 	{
-		m_mixerChannelNumber->setVisible((getTrackOperationsWidget()->width() + getTrackSettingsWidget()->width()) >= COMPACT_TRACK_WIDTH);
+		m_mixerChannelNumber->setVisible(trackContainerView()->getTrackHeadWidth() >= TrackContainerView::COMPACT_TRACK_HEAD_WIDTH);
 	};
 
 	connect(tcv, &TrackContainerView::trackHeadWidthChanged, this, updateChannelNumberVisibility);

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -61,12 +61,14 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	m_tlb->show();
 
 	m_mixerChannelNumber = new MixerChannelLcdSpinBox(2, getTrackSettingsWidget(), tr("Mixer channel"), this);
-	m_mixerChannelNumber->show();
 
-	connect(trackContainerView(), &TrackContainerView::trackHeadWidthChanged, this, [this](int width){
-		if (width < COMPACT_TRACK_WIDTH) { m_mixerChannelNumber->hide(); }
-		else { m_mixerChannelNumber->show(); }
-	});
+	auto updateChannelNumberVisibility = [this]()
+	{
+		m_mixerChannelNumber->setVisible((getTrackOperationsWidget()->width() + getTrackSettingsWidget()->width()) >= COMPACT_TRACK_WIDTH);
+	};
+
+	connect(trackContainerView(), &TrackContainerView::trackHeadWidthChanged, this, updateChannelNumberVisibility);
+	updateChannelNumberVisibility();
 
 	m_volumeKnob = new Knob(KnobType::Small17, tr("VOL"), getTrackSettingsWidget(), Knob::LabelRendering::LegacyFixedFontSize, tr("Track volume"));
 	m_volumeKnob->setVolumeKnob( true );

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -64,7 +64,7 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 
 	auto updateChannelNumberVisibility = [this]()
 	{
-		m_mixerChannelNumber->setVisible((getTrackOperationsWidget()->width() + getTrackSettingsWidget()->width()) >= COMPACT_TRACK_WIDTH);
+		m_mixerChannelNumber->setVisible(trackContainerView()->getTrackHeadWidth() >= TrackContainerView::COMPACT_TRACK_HEAD_WIDTH);
 	};
 
 	connect(trackContainerView(), &TrackContainerView::trackHeadWidthChanged, this, updateChannelNumberVisibility);

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -77,7 +77,6 @@ TrackContentWidget::TrackContentWidget( TrackView * parent ) :
 	m_embossOffset(0)
 {
 	setAcceptDrops( true );
-	setMouseTracking(true);
 
 	connect( parent->trackContainerView(),
 			SIGNAL( positionChanged( const lmms::TimePos& ) ),

--- a/src/gui/tracks/TrackView.cpp
+++ b/src/gui/tracks/TrackView.cpp
@@ -277,11 +277,11 @@ void TrackView::mousePressEvent( QMouseEvent * me )
 	}
 	else if( me->button() == Qt::LeftButton )
 	{
-		if (me->x() > widgetTotal - ResizeGripWidth && me->x() <= widgetTotal)
+		if (me->x() > widgetTotal - RESIZE_GRIP_WIDTH && me->x() <= widgetTotal)
 		{
 			m_action = Action::ResizeHorizontal;
 		}
-		else if (me->modifiers() & Qt::ShiftModifier || (me->y() > height() - ResizeGripWidth && me->x() <= widgetTotal))
+		else if (me->modifiers() & Qt::ShiftModifier || (me->y() > height() - RESIZE_GRIP_WIDTH && me->x() <= widgetTotal))
 		{
 			m_action = Action::ResizeVertical;
 			QCursor::setPos( mapToGlobal( QPoint( me->x(),
@@ -359,11 +359,11 @@ void TrackView::mouseMoveEvent( QMouseEvent * me )
 		m_trackContainerView->setTrackHeadWidth(me->x());
 		setCursor(Qt::SizeHorCursor);
 	}
-	else if (me->x() > widgetTotal - ResizeGripWidth && me->x() < widgetTotal)
+	else if (me->x() > widgetTotal - RESIZE_GRIP_WIDTH && me->x() < widgetTotal)
 	{
 		setCursor(Qt::SizeHorCursor);
 	}
-	else if (me->y() > height() - ResizeGripWidth && me->x() < widgetTotal)
+	else if (me->y() > height() - RESIZE_GRIP_WIDTH && me->x() < widgetTotal)
 	{
 		setCursor(Qt::SizeVerCursor);
 	}

--- a/src/gui/tracks/TrackView.cpp
+++ b/src/gui/tracks/TrackView.cpp
@@ -31,7 +31,6 @@
 #include <QPainter>
 #include <QStyleOption>
 #include <QtGlobal>
-#include <QDebug>
 
 
 #include "AudioEngine.h"
@@ -67,6 +66,8 @@ TrackView::TrackView( Track * track, TrackContainerView * tcv ) :
 	m_trackOperationsWidget( this ),    /*!< Our trackOperationsWidget */
 	m_trackSettingsWidget( this ),      /*!< Our trackSettingsWidget */
 	m_trackContentWidget( this ),       /*!< Our trackContentWidget */
+	m_heightResizeLine(new TrackResizeLine(this, TrackView::Action::ResizeVertical, Qt::SizeVerCursor)),
+	m_widthResizeLine(new TrackResizeLine(this, TrackView::Action::ResizeHorizontal, Qt::SizeHorCursor)),
 	m_action( Action::None )                /*!< The action we're currently performing */
 {
 	setAutoFillBackground( true );
@@ -84,12 +85,12 @@ TrackView::TrackView( Track * track, TrackContainerView * tcv ) :
 	layout->addWidget( &m_trackContentWidget, 1 );
 	setFixedHeight( m_track->getHeight() );
 
+	m_heightResizeLine->raise();
+	m_widthResizeLine->raise();
+
 	resizeEvent( nullptr );
 
 	setAcceptDrops( true );
-	setMouseTracking(true);
-	m_trackSettingsWidget.setMouseTracking(true);
-	m_trackSettingsWidget.setMouseTracking(true);
 	setAttribute( Qt::WA_DeleteOnClose, true );
 
 
@@ -108,7 +109,7 @@ TrackView::TrackView( Track * track, TrackContainerView * tcv ) :
 	connect( &m_track->m_soloModel, SIGNAL(dataChanged()),
 			m_track, SLOT(toggleSolo()), Qt::DirectConnection );
 	
-	connect(m_trackContainerView, &TrackContainerView::trackHeadWidthChanged, this, &TrackView::updateWidth);
+	connect(m_trackContainerView, &TrackContainerView::trackHeadWidthChanged, this, &TrackView::updateTrackHeadWidth);
 
 	auto trackGrip = m_trackOperationsWidget.getTrackGrip();
 	connect(trackGrip, &TrackGrip::grabbed, this, &TrackView::onTrackGripGrabbed);
@@ -140,6 +141,9 @@ void TrackView::resizeEvent( QResizeEvent * re )
 	m_trackSettingsWidget.setFixedSize(m_trackContainerView->getTrackHeadWidth() - m_trackOperationsWidget.width(), height() - 1);
 
 	m_trackContentWidget.setFixedHeight(height());
+
+	m_heightResizeLine->setGeometry(0, height()-RESIZE_GRIP_WIDTH, width(), RESIZE_GRIP_WIDTH);
+	m_widthResizeLine->setGeometry(trackContainerView()->getTrackHeadWidth()-RESIZE_GRIP_WIDTH, 0, RESIZE_GRIP_WIDTH, height());
 }
 
 
@@ -243,63 +247,6 @@ void TrackView::dropEvent( QDropEvent * de )
 
 
 
-/*! \brief Handle a mouse press event on this track View.
- *
- *  If this track container supports rubber band selection, let the
- *  widget handle that and don't bother with any other handling.
- *
- *  If the left mouse button is pressed, we handle two things.  If
- *  SHIFT is pressed, then we resize vertically.  Otherwise we start
- *  the process of moving this track to a new position.
- *
- *  Otherwise we let the widget handle the mouse event as normal.
- *
- *  \param me the MouseEvent to handle.
- */
-void TrackView::mousePressEvent( QMouseEvent * me )
-{
-
-	// If previously dragged too small, restore on shift-leftclick
-	if( height() < DEFAULT_TRACK_HEIGHT &&
-		me->modifiers() & Qt::ShiftModifier &&
-		me->button() == Qt::LeftButton )
-	{
-		setFixedHeight( DEFAULT_TRACK_HEIGHT );
-		m_track->setHeight( DEFAULT_TRACK_HEIGHT );
-	}
-
-
-	int widgetTotal = m_trackContainerView->getTrackHeadWidth();
-
-	if( m_trackContainerView->allowRubberband() == true  && me->x() > widgetTotal )
-	{
-		QWidget::mousePressEvent( me );
-	}
-	else if( me->button() == Qt::LeftButton )
-	{
-		if (me->x() > widgetTotal - RESIZE_GRIP_WIDTH && me->x() <= widgetTotal)
-		{
-			m_action = Action::ResizeHorizontal;
-		}
-		else if (me->modifiers() & Qt::ShiftModifier || (me->y() > height() - RESIZE_GRIP_WIDTH && me->x() <= widgetTotal))
-		{
-			m_action = Action::ResizeVertical;
-			QCursor::setPos( mapToGlobal( QPoint( me->x(),
-								height() ) ) );
-			QCursor c( Qt::SizeVerCursor);
-			QApplication::setOverrideCursor( c );
-		}
-
-		me->accept();
-	}
-	else
-	{
-		QWidget::mousePressEvent( me );
-	}
-}
-
-
-
 
 /*! \brief Handle a mouse move event on this track View.
  *
@@ -319,9 +266,9 @@ void TrackView::mousePressEvent( QMouseEvent * me )
  */
 void TrackView::mouseMoveEvent( QMouseEvent * me )
 {
-	int widgetTotal = m_trackContainerView->getTrackHeadWidth();
+	int trackHeadWidth = m_trackContainerView->getTrackHeadWidth();
 
-	if( m_trackContainerView->allowRubberband() == true && me->x() > widgetTotal )
+	if (m_trackContainerView->allowRubberband() && me->x() > trackHeadWidth)
 	{
 		QWidget::mouseMoveEvent( me );
 	}
@@ -352,24 +299,10 @@ void TrackView::mouseMoveEvent( QMouseEvent * me )
 	else if (m_action == Action::ResizeVertical)
 	{
 		resizeToHeight(me->y());
-		setCursor(Qt::SizeVerCursor);
 	}
 	else if (m_action == Action::ResizeHorizontal)
 	{
 		m_trackContainerView->setTrackHeadWidth(me->x());
-		setCursor(Qt::SizeHorCursor);
-	}
-	else if (me->x() > widgetTotal - RESIZE_GRIP_WIDTH && me->x() < widgetTotal)
-	{
-		setCursor(Qt::SizeHorCursor);
-	}
-	else if (me->y() > height() - RESIZE_GRIP_WIDTH && me->x() < widgetTotal)
-	{
-		setCursor(Qt::SizeVerCursor);
-	}
-	else
-	{
-		setCursor(Qt::ArrowCursor);
 	}
 
 	if( height() < DEFAULT_TRACK_HEIGHT )
@@ -380,22 +313,6 @@ void TrackView::mouseMoveEvent( QMouseEvent * me )
 
 
 
-/*! \brief Handle a mouse release event on this track View.
- *
- *  \param me the MouseEvent to handle.
- */
-void TrackView::mouseReleaseEvent( QMouseEvent * me )
-{
-	m_action = Action::None;
-	while( QApplication::overrideCursor() != nullptr )
-	{
-		QApplication::restoreOverrideCursor();
-	}
-	m_trackOperationsWidget.update();
-	setCursor(Qt::ArrowCursor);
-
-	QWidget::mouseReleaseEvent( me );
-}
 
 void TrackView::wheelEvent(QWheelEvent* we)
 {
@@ -483,9 +400,40 @@ void TrackView::resizeToHeight(int h)
 	m_track->setHeight(height());
 }
 
-void TrackView::updateWidth(int width)
+void TrackView::updateTrackHeadWidth(int width)
 {
 	m_trackSettingsWidget.setFixedWidth(width - m_trackOperationsWidget.width());
+	m_widthResizeLine->move(trackContainerView()->getTrackHeadWidth(), 0);
 }
+
+
+
+
+TrackResizeLine::TrackResizeLine(TrackView* tv, TrackView::Action action, Qt::CursorShape cursor):
+	QWidget(tv),
+	m_trackView(tv),
+	m_action(action)
+{
+	setCursor(cursor);
+	setAttribute(Qt::WA_TranslucentBackground);
+	setAttribute(Qt::WA_TransparentForMouseEvents, false);
+}
+
+
+void TrackResizeLine::mousePressEvent(QMouseEvent *me)
+{
+	// TODO we should propagate right clicks and ctrl+drag to the TrackContentWidget
+	// instead of just silently ignoring it here
+	if (me->button() != Qt::LeftButton || me->modifiers()) { return; }
+
+	m_trackView->m_action = m_action;
+}
+
+void TrackResizeLine::mouseReleaseEvent(QMouseEvent *me)
+{
+	m_trackView->m_action = TrackView::Action::None;
+}
+
+
 
 } // namespace lmms::gui


### PR DESCRIPTION
- Fixes bug where new instruments would not have LCD hidden in compact mode.
- Fixes bug where mouse cursor gets stuck in resize mode between track controls.
- Move common code in `SongEditor` and `PatternEditor` to `TrackContainerView`.
- Restore track head size on project reload.
- Resize track head in Pattern Editor when the windows is resized bigger again.
- Allow resizing tracks in the track content area.

One problem is that the new `ResizeTrackLine` doesn't propagate selection/right click though to the widget below. Possible solutions: don't draw the resize line over the `TrackContentWidget`. Or hack up something like:

```cpp
ResizeTrackLine::mousePressEvent(QMouseEvent* event)
{
    QMouseEvent newEvent(event->type(), newRelativePos, ...);
    QApplication::sendEvent(trackContentWidget, &newEvent);
}
```

